### PR TITLE
Fix both deployment paths against Pelican beta36 (fixes #6, likely #2)

### DIFF
--- a/Pelican/Pelican.php
+++ b/Pelican/Pelican.php
@@ -275,7 +275,7 @@ class Pelican extends Server
         ];
         if ($deploymentData['auto_deploy']) {
             $serverCreationData['deploy'] = [
-                'locations' => [$settings['node']] ?? [],
+                'locations' => $settings['node'] ? [$settings['node']] : [],
                 'dedicated_ip' => $settings['dedicated_ip'] ?? false,
                 'port_range' => $settings['port_range'] ?? [],
                 'tags' => ['PaymenterDeployment'],
@@ -317,6 +317,7 @@ class Pelican extends Server
         }
 
         $nodes = $this->request('/api/application/nodes/deployable', 'get', [
+            'include' => 'allocations',
             'memory' => $settings['memory'],
             'disk' => $settings['disk'],
         ]);


### PR DESCRIPTION
Two one-line fixes that make both deployment paths work against Pelican `v1.0.0-beta36`. Tested 11 Aug 2026 by driving the extension end-to-end against a live beta36 panel (Paymenter v1.5.7, PHP 8.4): with these changes, both auto-deploy and port-array requests pass validation, select a node by tag, get an allocation assigned, auto-create the panel user, and proceed to the Wings call.

## Fix 1 — auto-deploy sent `locations: [null]` when no node is pinned

```php
'locations' => [$settings['node']] ?? [],
```

`??` binds after the array literal, so this expression can never produce `[]` — with no node pinned it sends `[null]`, and beta36 rejects the request with `The deploy.locations.0 field is required when deploy.locations is present.` Changed to:

```php
'locations' => $settings['node'] ? [$settings['node']] : [],
```

This is very likely the root cause of #2 as well ("No nodes satisfying the requirements") — on beta36, `deploy.locations` is a deprecated alias for `deploy.tags` and is **ignored** whenever `tags` is present, so node selection is done purely by the `PaymenterDeployment` tag this extension already sends. A node without that tag can never match.

## Fix 2 — `/nodes/deployable` response has no `relationships` key (fixes #6)

beta36 only embeds each node's allocations when they are requested as an include. Without `'include' => 'allocations'`, the response carries no `relationships` key, and line 333 (`$node['relationships']['allocations']['data']`) fails. Under PHP 8.x the undefined-key read is a warning, so it degrades into `collect(null)` → zero available ports → the misleading `Not enough allocations found for deployment. Found: 0` rather than the exception in the original report — but it is the same defect.

## Relationship to #7

We tested #7's premise on beta36: a `deploy.tags` request whose daemon call fails is **rolled back cleanly** — server creation is transactional and no orphan server with a null allocation is left behind. So on beta36 the tags-based deploy path works as designed once the two lines above are fixed, and the larger client-side allocation-picking rewrite in #7 wasn't needed in our testing. (Not a knock on #7 — the beta34 behaviour it works around may well have been real on that version.)

Happy to adjust anything — thanks for the extension!
